### PR TITLE
Make it work on non-64bits platforms

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -62,8 +62,9 @@ impl<R: io::Write> WriteVarInt for R {
         }
     }
 
-    #[cfg(target_arch = "x86_64")] // TODO: better cfg detection of this
     fn write_usize_varint(&mut self, val: usize) -> io::Result<()> {
+        // Note: assumes that `usize` is not larger than 64bits, which is the case for every single
+        // platform supported by Rust today.
         self.write_u64_varint(val as u64)
     }
 }


### PR DESCRIPTION
Fixes the library so that it compiles on non-64bits-PC platforms.

This PR doesn't pass clippy, mostly because:
1 - Clippy has gotten several new warnings since the previous PR which was back in 2016.
2 - This PR introduces a new warning, which cannot be fixed except by adding an `#[allow]`, which to me more or less defeats the point of using clippy in the first place.

Therefor I would suggest to drop this strict clippy requirement altogether.